### PR TITLE
Add GitHub Actions workflow to comment on Vercel deployment errors in PRs

### DIFF
--- a/.github/workflows/vercel-fail-comment.yml
+++ b/.github/workflows/vercel-fail-comment.yml
@@ -28,7 +28,7 @@ jobs:
 
           # Find the most recent deployment for this PR branch
           DEPLOYMENT_ID=$(echo "$response" | jq -r --arg branch "$PR_BRANCH" \
-            '.deployments[] | select(.meta.gitBranch==$branch) | .uid' | head -n1)
+            '.deployments[] | select(.meta.gitBranch? == $branch) | .uid' | head -n1)
 
           if [ -z "$DEPLOYMENT_ID" ]; then
             echo "No deployment found for this PR branch."


### PR DESCRIPTION


This workflow triggers on pull request events and checks the status of the latest Vercel deployment. If the deployment fails, it fetches error logs and posts a comment on the PR with the relevant error details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that posts diagnostic comments on pull requests when deployments fail: it detects matching deployments, extracts concise error snippets (up to 20 lines), includes a failure notice and a link to full deployment logs, and skips commenting if no relevant deployment is found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->