### PR TITLE
Comment vercel error stack in GitHub

### DIFF
--- a/.github/workflows/vercel-fail-comment.yml
+++ b/.github/workflows/vercel-fail-comment.yml
@@ -1,6 +1,12 @@
 name: Vercel Deployment Monitor
 
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "The pull request number to monitor"
+        required: true
+        default: "1"
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated PR monitoring for preview deployments: the workflow watches PR preview builds and posts concise comments when a preview fails or times out, including a short error excerpt and a link to full deployment logs to speed debugging.
  * Triggers only on PR events (opened, reopened, updated) and avoids posting for successful previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->